### PR TITLE
Support nmap's official graphical frontend (Zenmap)

### DIFF
--- a/port-scanners.nix
+++ b/port-scanners.nix
@@ -9,7 +9,27 @@
     ipscan
     masscan
     naabu
-    nmap
+
+    # NixOS/nixpkgs#287288
+    (nmap.overrideAttrs(old: rec {
+      nativeBuildInputs = old.nativeBuildInputs ++ [
+        gobject-introspection
+        (python311.withPackages(pypkgs: [
+          pypkgs.pygobject3
+        ]))
+        wrapGAppsHook
+      ];
+
+      buildInputs = old.buildInputs ++ [ gtk3 ];
+
+      configureFlags = lib.remove "--without-zenmap" (lib.flatten old.configureFlags);
+
+      installPhase = ''
+        cd zenmap
+        python setup.py install --prefix=$out
+        sed -i "58a sys.path.append(\"$out/lib/python${python3.sourceVersion.major}.${python3.sourceVersion.minor}/site-packages/\")" $out/bin/zenmap
+      '';
+    }))
     udpx
     sx-go
     rustscan


### PR DESCRIPTION
This package override was tested using my own personal configuration.nix file and found to work properly for getting Zenmap onto NixOS, so might want to include this.